### PR TITLE
feat: add capture time sorting functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,11 +21,29 @@ uv run python src/main.py download --max-projects 8
 # Look back more hours for marker files (default: 24)
 uv run python src/main.py download --hours-back 48
 
+# Limit images per project (default: 20)
+uv run python src/main.py download --max-images 5
+
+# Download all images per project (no limit)
+uv run python src/main.py download --max-images 0
+
 # Correct image rotations (after download)
 uv run python src/main.py correct-rotations
 
 # Force re-process all images (overwrite existing)
 uv run python src/main.py correct-rotations --overwrite
+
+# Sort/rename images by capture time (after download)
+uv run python src/main.py capture-time-sort
+
+# Sort with custom input directory
+uv run python src/main.py capture-time-sort --input-dir my_projects
+
+# Sort to output directory (copy files)
+uv run python src/main.py capture-time-sort --output-dir sorted_images
+
+# Force overwrite existing renamed images
+uv run python src/main.py capture-time-sort --overwrite
 
 # Run tests
 uv run pytest
@@ -43,6 +61,16 @@ The project includes an image rotation correction feature that uses rotation dat
 - **Accuracy**: 100% accurate rotation detection (no ML model inference needed)
 - **Processing**: Applies corrections based on rotation values: `CW90`, `CW180`, `CW270`, or `None`
 - **Performance**: Fast processing, limited only by image I/O
+
+## Capture Time Sorting
+
+The project includes a capture time sorting feature that organizes images by renaming them with structured filenames:
+
+- **Data Source**: Uses capture time, camera model, and serial number from `<project_uuid>.v3.gz` files
+- **Filename Pattern**: `<model>_<camera_serial>_<capture_time>_<image_uuid>.jpg`
+- **Example**: `EOS_R6_182027002738_20250712_023256_9e8161ff-abb8-4332-bb8d-096ef9d37c68.jpg`
+- **Collision Avoidance**: Uses image UUID to ensure filename uniqueness
+- **Processing**: Sanitizes camera model names and formats timestamps for filesystem compatibility
 
 ## Performance & Parallelization
 

--- a/src/preview_wrangler/capture_time_sorter.py
+++ b/src/preview_wrangler/capture_time_sorter.py
@@ -1,0 +1,371 @@
+"""
+Capture time sorting using v3.gz ML upload file data.
+
+This module renames JPEG files using metadata from project ML upload files
+to create organized filenames based on camera model, serial, capture time, and image UUID.
+"""
+
+import gzip
+import json
+import logging
+import re
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
+
+
+class CaptureTimeSorter:
+    """Sorts/renames images using capture time data from v3.gz ML upload files."""
+
+    def __init__(
+        self,
+        input_dir: Path,
+        output_dir: Optional[Path] = None,
+        overwrite: bool = False,
+    ):
+        """
+        Initialize the capture time sorter.
+
+        Args:
+            input_dir: Directory containing project directories with images and v3.gz files
+            output_dir: Directory to save renamed images (None = in-place)
+            overwrite: Whether to overwrite existing renamed images
+        """
+        self.input_dir = Path(input_dir)
+        self.output_dir = Path(output_dir) if output_dir else None
+        self.overwrite = overwrite
+
+    def _parse_v3_file(self, v3_path: Path) -> dict[str, dict[str, Any]]:
+        """
+        Parse a v3.gz file to extract capture time metadata for images.
+
+        Args:
+            v3_path: Path to the v3.gz file
+
+        Returns:
+            Dictionary mapping image IDs to their metadata
+        """
+        metadata = {}
+
+        try:
+            with gzip.open(v3_path, "rt") as f:
+                data = json.load(f)
+
+            if "images" in data:
+                for image in data["images"]:
+                    if "id" in image and "meta" in image:
+                        image_id = image["id"]
+                        meta = image["meta"]
+
+                        # Extract required fields
+                        required_fields = ["capture_time", "model", "camera_serial"]
+                        if all(field in meta for field in required_fields):
+                            metadata[image_id] = {
+                                "capture_time": meta["capture_time"],
+                                "model": meta["model"],
+                                "camera_serial": meta["camera_serial"],
+                            }
+                        else:
+                            logger.debug(f"Missing required metadata for image {image_id}")
+
+        except Exception as e:
+            logger.error(f"Error parsing {v3_path}: {e}")
+
+        return metadata
+
+    def _sanitize_filename_component(self, component: str) -> str:
+        """
+        Sanitize a filename component by replacing problematic characters.
+
+        Args:
+            component: Component to sanitize
+
+        Returns:
+            Sanitized component safe for filenames
+        """
+        # Replace spaces and special characters with underscores
+        sanitized = re.sub(r"[^\w\-.]", "_", component)
+        # Remove multiple consecutive underscores
+        sanitized = re.sub(r"_+", "_", sanitized)
+        # Remove leading/trailing underscores
+        sanitized = sanitized.strip("_")
+        return sanitized
+
+    def _format_capture_time(self, capture_time: str) -> str:
+        """
+        Format capture time from ISO format to YYYYMMDD_HHMMSS.
+
+        Args:
+            capture_time: ISO format timestamp (e.g., "2025-07-12T02:32:56")
+
+        Returns:
+            Formatted timestamp (e.g., "20250712_023256")
+        """
+        try:
+            # Parse ISO format timestamp
+            dt = datetime.fromisoformat(capture_time.replace("Z", "+00:00"))
+            return dt.strftime("%Y%m%d_%H%M%S")
+        except Exception as e:
+            logger.warning(f"Error formatting capture time '{capture_time}': {e}")
+            # Return sanitized original as fallback
+            return self._sanitize_filename_component(capture_time)
+
+    def _generate_new_filename(self, image_id: str, metadata: dict[str, Any]) -> str:
+        """
+        Generate new filename from metadata.
+
+        Args:
+            image_id: Image UUID
+            metadata: Metadata dictionary with model, camera_serial, capture_time
+
+        Returns:
+            New filename in format: model_serial_time_uuid.jpg
+        """
+        model = self._sanitize_filename_component(metadata["model"])
+        serial = self._sanitize_filename_component(metadata["camera_serial"])
+        formatted_time = self._format_capture_time(metadata["capture_time"])
+
+        return f"{model}_{serial}_{formatted_time}_{image_id}.jpg"
+
+    def _get_image_path(self, project_dir: Path, image_id: str) -> Optional[Path]:
+        """
+        Get JPEG file path from image ID.
+
+        Args:
+            project_dir: Project directory to search
+            image_id: Image ID from v3 file (matches JPEG filename)
+
+        Returns:
+            Path to JPEG file, or None if not found
+        """
+        # Try common JPEG extensions
+        for ext in [".jpg", ".jpeg", ".JPG", ".JPEG"]:
+            jpeg_path = project_dir / f"{image_id}{ext}"
+            if jpeg_path.exists():
+                return jpeg_path
+
+        return None
+
+    def _get_output_path(self, input_path: Path, new_filename: str) -> Path:
+        """
+        Get the output path for a renamed image.
+
+        Args:
+            input_path: Input image path
+            new_filename: New filename to use
+
+        Returns:
+            Output path for the renamed image
+        """
+        if self.output_dir:
+            # Maintain directory structure in output
+            relative_path = input_path.relative_to(self.input_dir)
+            return self.output_dir / relative_path.parent / new_filename
+        else:
+            # In-place renaming
+            return input_path.parent / new_filename
+
+    def _rename_image(self, input_path: Path, output_path: Path) -> bool:
+        """
+        Rename/copy an image file.
+
+        Args:
+            input_path: Input image path
+            output_path: Output image path
+
+        Returns:
+            True if file was renamed/copied, False if skipped
+        """
+        # Check if already exists and not overwriting
+        if output_path.exists() and not self.overwrite:
+            logger.debug(f"Skipping {input_path.name} - output already exists")
+            return False
+
+        # Skip if input and output are the same
+        if str(input_path) == str(output_path):
+            logger.debug(f"Skipping {input_path.name} - already has correct name")
+            return False
+
+        try:
+            # Ensure output directory exists
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+
+            if self.output_dir:
+                # Copy to output directory
+                shutil.copy2(input_path, output_path)
+            else:
+                # In-place rename
+                input_path.rename(output_path)
+
+            logger.debug(f"Renamed {input_path.name} -> {output_path.name}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error renaming {input_path}: {e}")
+            raise
+
+    def process_projects(self) -> dict[str, Any]:
+        """
+        Process all projects in the input directory.
+
+        Returns:
+            Summary statistics of the sorting process
+        """
+        # Find all project directories (those containing .v3.gz files)
+        project_dirs = []
+        for item in self.input_dir.iterdir():
+            if item.is_dir():
+                # Filter out macOS metadata files (._*) and get only real v3.gz files
+                v3_files = [f for f in item.glob("*.v3.gz") if not f.name.startswith("._")]
+                if v3_files:
+                    project_dirs.append(item)
+
+        if not project_dirs:
+            logger.info("No project directories with v3.gz files found")
+            return {
+                "total_projects": 0,
+                "total_images": 0,
+                "renamed": 0,
+                "skipped": 0,
+                "errors": 0,
+            }
+
+        logger.info(f"Found {len(project_dirs)} project directories")
+
+        # Process each project
+        total_stats: dict[str, Any] = {
+            "total_projects": len(project_dirs),
+            "total_images": 0,
+            "renamed": 0,
+            "skipped": 0,
+            "errors": 0,
+        }
+
+        for project_dir in tqdm(project_dirs, desc="Processing projects"):
+            try:
+                project_stats = self._process_single_project(project_dir)
+
+                # Aggregate stats
+                total_stats["total_images"] += project_stats["total_images"]
+                total_stats["renamed"] += project_stats["renamed"]
+                total_stats["skipped"] += project_stats["skipped"]
+                total_stats["errors"] += project_stats["errors"]
+
+            except Exception as e:
+                logger.error(f"Error processing project {project_dir.name}: {e}")
+                total_stats["errors"] += 1
+
+        # Log summary
+        logger.info("\nCapture Time Sorting Summary:")
+        logger.info(f"  Total projects: {total_stats['total_projects']}")
+        logger.info(f"  Total images: {total_stats['total_images']}")
+        logger.info(f"  Images renamed: {total_stats['renamed']}")
+        logger.info(f"  Images skipped: {total_stats['skipped']}")
+        logger.info(f"  Errors: {total_stats['errors']}")
+
+        return total_stats
+
+    def _process_single_project(self, project_dir: Path) -> dict[str, Any]:
+        """
+        Process a single project directory.
+
+        Args:
+            project_dir: Project directory path
+
+        Returns:
+            Statistics for this project
+        """
+        # Find the v3.gz file (exclude macOS metadata files)
+        v3_files = [f for f in project_dir.glob("*.v3.gz") if not f.name.startswith("._")]
+        if not v3_files:
+            return {
+                "total_images": 0,
+                "renamed": 0,
+                "skipped": 0,
+                "errors": 0,
+            }
+
+        v3_file = v3_files[0]  # Should only be one per project
+
+        # Parse metadata
+        metadata_map = self._parse_v3_file(v3_file)
+        if not metadata_map:
+            logger.debug(f"No capture time metadata found in {v3_file}")
+            return {
+                "total_images": 0,
+                "renamed": 0,
+                "skipped": 0,
+                "errors": 0,
+            }
+
+        # Find and process images
+        stats: dict[str, Any] = {
+            "total_images": 0,
+            "renamed": 0,
+            "skipped": 0,
+            "errors": 0,
+        }
+
+        for image_id, metadata in metadata_map.items():
+            # Get the corresponding JPEG file path
+            jpeg_path = self._get_image_path(project_dir, image_id)
+            if not jpeg_path:
+                logger.debug(f"JPEG not found for image ID {image_id}")
+                continue
+
+            stats["total_images"] += 1
+
+            try:
+                # Generate new filename
+                new_filename = self._generate_new_filename(image_id, metadata)
+
+                # Get output path
+                output_path = self._get_output_path(jpeg_path, new_filename)
+
+                # Rename image
+                was_renamed = self._rename_image(jpeg_path, output_path)
+
+                # Update stats
+                if was_renamed:
+                    stats["renamed"] += 1
+                else:
+                    stats["skipped"] += 1
+
+            except Exception as e:
+                logger.error(f"Error processing {jpeg_path}: {e}")
+                stats["errors"] += 1
+
+        return stats
+
+
+def capture_time_sort(input_dir: str, output_dir: Optional[str] = None, overwrite: bool = False):
+    """
+    Main function to sort images by capture time using v3.gz data.
+
+    Args:
+        input_dir: Directory containing project directories
+        output_dir: Output directory (None = in-place)
+        overwrite: Overwrite existing files
+    """
+    # Create sorter and process images
+    sorter = CaptureTimeSorter(
+        input_dir=Path(input_dir),
+        output_dir=Path(output_dir) if output_dir else None,
+        overwrite=overwrite,
+    )
+
+    stats = sorter.process_projects()
+
+    # Save statistics
+    stats_file = Path.home() / ".preview_wrangler" / "capture_time_sort_stats.json"
+    stats_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(stats_file, "w") as f:
+        json.dump(stats, f, indent=2)
+
+    logger.info(f"Statistics saved to {stats_file}")
+    return stats

--- a/src/preview_wrangler/rotation_corrector_v3.py
+++ b/src/preview_wrangler/rotation_corrector_v3.py
@@ -336,7 +336,7 @@ class V3RotationCorrector:
             Statistics for this image
         """
         image_id, rotation, jpeg_path = task
-        result = {
+        result: dict[str, Any] = {
             "corrected": 0,
             "skipped": 0,
             "errors": 0,

--- a/src/preview_wrangler/rotation_corrector_v3.py
+++ b/src/preview_wrangler/rotation_corrector_v3.py
@@ -8,6 +8,7 @@ rotation data from the project ML upload files.
 import gzip
 import json
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Optional
 
@@ -25,6 +26,7 @@ class V3RotationCorrector:
         input_dir: Path,
         output_dir: Optional[Path] = None,
         overwrite: bool = False,
+        max_workers: int = 4,
     ):
         """
         Initialize the rotation corrector.
@@ -33,10 +35,12 @@ class V3RotationCorrector:
             input_dir: Directory containing project directories with images and v3.gz files
             output_dir: Directory to save corrected images (None = in-place)
             overwrite: Whether to overwrite existing corrected images
+            max_workers: Number of worker threads for parallel processing
         """
         self.input_dir = Path(input_dir)
         self.output_dir = Path(output_dir) if output_dir else None
         self.overwrite = overwrite
+        self.max_workers = max_workers
 
     def _parse_v3_file(self, v3_path: Path) -> dict[str, str]:
         """
@@ -143,8 +147,8 @@ class V3RotationCorrector:
 
             # Open and rotate image
             with Image.open(input_path) as img:
-                # Convert to RGB if necessary (for JPEG output)
-                if img.mode not in ("RGB", "L"):
+                # Only convert to RGB if not already RGB/RGBA/L
+                if img.mode not in ("RGB", "RGBA", "L"):
                     img = img.convert("RGB")
 
                 # Apply rotation
@@ -189,7 +193,8 @@ class V3RotationCorrector:
         project_dirs = []
         for item in self.input_dir.iterdir():
             if item.is_dir():
-                v3_files = list(item.glob("*.v3.gz"))
+                # Filter out macOS metadata files (._*) and get only real v3.gz files
+                v3_files = [f for f in item.glob("*.v3.gz") if not f.name.startswith("._")]
                 if v3_files:
                     project_dirs.append(item)
 
@@ -256,8 +261,8 @@ class V3RotationCorrector:
         Returns:
             Statistics for this project
         """
-        # Find the v3.gz file
-        v3_files = list(project_dir.glob("*.v3.gz"))
+        # Find the v3.gz file (exclude macOS metadata files)
+        v3_files = [f for f in project_dir.glob("*.v3.gz") if not f.name.startswith("._")]
         if not v3_files:
             return {
                 "total_images": 0,
@@ -281,46 +286,85 @@ class V3RotationCorrector:
                 "corrections_by_angle": {0: 0, 90: 0, 180: 0, 270: 0},
             }
 
-        # Find and process images
+        # Find valid images
+        image_tasks = []
+        for image_id, rotation in rotation_data.items():
+            jpeg_path = self._get_image_path(project_dir, image_id)
+            if jpeg_path:
+                image_tasks.append((image_id, rotation, jpeg_path))
+
+        if not image_tasks:
+            return {
+                "total_images": 0,
+                "corrected": 0,
+                "skipped": 0,
+                "errors": 0,
+                "corrections_by_angle": {0: 0, 90: 0, 180: 0, 270: 0},
+            }
+
+        # Process images in parallel
         stats: dict[str, Any] = {
-            "total_images": 0,
+            "total_images": len(image_tasks),
             "corrected": 0,
             "skipped": 0,
             "errors": 0,
             "corrections_by_angle": {0: 0, 90: 0, 180: 0, 270: 0},
         }
 
-        for image_id, rotation in rotation_data.items():
-            # Get the corresponding JPEG file path
-            jpeg_path = self._get_image_path(project_dir, image_id)
-            if not jpeg_path:
-                logger.debug(f"JPEG not found for image ID {image_id}")
-                continue
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            results = list(executor.map(self._process_image_task, image_tasks))
 
-            stats["total_images"] += 1
-
-            try:
-                # Convert rotation to degrees
-                degrees = self._rotation_to_degrees(rotation)
-
-                # Get output path
-                output_path = self._get_output_path(jpeg_path)
-
-                # Apply rotation
-                was_rotated = self._apply_rotation(jpeg_path, output_path, degrees)
-
-                # Update stats
-                stats["corrections_by_angle"][degrees] += 1
-                if was_rotated:
-                    stats["corrected"] += 1
-                else:
-                    stats["skipped"] += 1
-
-            except Exception as e:
-                logger.error(f"Error processing {jpeg_path}: {e}")
-                stats["errors"] += 1
+        # Aggregate results
+        for result in results:
+            if result:
+                stats["corrected"] += result["corrected"]
+                stats["skipped"] += result["skipped"]
+                stats["errors"] += result["errors"]
+                for angle, count in result["corrections_by_angle"].items():
+                    stats["corrections_by_angle"][angle] += count
 
         return stats
+
+    def _process_image_task(self, task: tuple[str, str, Path]) -> dict[str, Any]:
+        """
+        Process a single image rotation task.
+
+        Args:
+            task: Tuple of (image_id, rotation, jpeg_path)
+
+        Returns:
+            Statistics for this image
+        """
+        image_id, rotation, jpeg_path = task
+        result = {
+            "corrected": 0,
+            "skipped": 0,
+            "errors": 0,
+            "corrections_by_angle": {0: 0, 90: 0, 180: 0, 270: 0},
+        }
+
+        try:
+            # Convert rotation to degrees
+            degrees = self._rotation_to_degrees(rotation)
+
+            # Get output path
+            output_path = self._get_output_path(jpeg_path)
+
+            # Apply rotation
+            was_rotated = self._apply_rotation(jpeg_path, output_path, degrees)
+
+            # Update stats
+            result["corrections_by_angle"][degrees] += 1
+            if was_rotated:
+                result["corrected"] += 1
+            else:
+                result["skipped"] += 1
+
+        except Exception as e:
+            logger.error(f"Error processing {jpeg_path}: {e}")
+            result["errors"] += 1
+
+        return result
 
 
 def correct_rotations_v3(input_dir: str, output_dir: Optional[str] = None, overwrite: bool = False):


### PR DESCRIPTION
## Summary
- Add new capture time sorting functionality that renames images using metadata from v3.gz files
- Integrate sorting command into CLI with options for input/output directories and overwrite behavior
- Enhance file downloader to avoid downloading macOS metadata files (._*)
- Improve rotation corrector with better logging and metadata handling
- Update documentation with capture time sorting usage

## Key Features
- **Filename Pattern**: `<model>_<camera_serial>_<capture_time>_<image_uuid>.jpg`
- **Example**: `EOS_R6_182027002738_20250712_023256_9e8161ff-abb8-4332-bb8d-096ef9d37c68.jpg`
- **Data Source**: Uses capture time, camera model, and serial number from `<project_uuid>.v3.gz` files
- **Collision Avoidance**: Uses image UUID to ensure filename uniqueness
- **Processing Options**: In-place renaming or copy to output directory

## Test plan
- [ ] Test basic capture time sorting with default settings
- [ ] Test sorting with custom input directory
- [ ] Test sorting with output directory (copy mode)
- [ ] Test overwrite functionality
- [ ] Verify filename sanitization works correctly
- [ ] Confirm macOS metadata files are excluded from processing

🤖 Generated with [Claude Code](https://claude.ai/code)