### PR TITLE
feat: add date range filtering for orphan cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,24 @@ uv run python src/main.py capture-time-sort --output-dir sorted_images
 # Force overwrite existing renamed images
 uv run python src/main.py capture-time-sort --overwrite
 
+# Clean up orphaned preview files (dry run by default, preserves ML upload files)
+uv run python src/main.py clean-orphans
+
+# Clean orphans with custom marker window (default: 7 days back)
+uv run python src/main.py clean-orphans --days-back 14
+
+# Clean orphans with specific date range
+uv run python src/main.py clean-orphans --date-from 2024-01-01 --date-to 2024-01-31
+
+# Clean orphans from specific start date to today
+uv run python src/main.py clean-orphans --date-from 2024-01-15
+
+# Generate a report of orphaned preview files
+uv run python src/main.py clean-orphans --report orphans_report.md
+
+# Actually delete orphaned preview files (after reviewing dry run)
+uv run python src/main.py clean-orphans --no-dry-run
+
 # Run tests
 uv run pytest
 
@@ -71,6 +89,17 @@ The project includes a capture time sorting feature that organizes images by ren
 - **Example**: `EOS_R6_182027002738_20250712_023256_9e8161ff-abb8-4332-bb8d-096ef9d37c68.jpg`
 - **Collision Avoidance**: Uses image UUID to ensure filename uniqueness
 - **Processing**: Sanitizes camera model names and formats timestamps for filesystem compatibility
+
+## Orphan Data Cleanup
+
+The project includes an orphan data cleanup feature that identifies and removes orphaned preview files while preserving ML upload files:
+
+- **Data Source**: Downloads latest S3 inventory CSV files and cross-references with marker files
+- **Detection**: Finds projects with preview data in inventory but no valid marker files within the specified time window
+- **Date Filtering**: Supports both relative (`--days-back`) and absolute (`--date-from`/`--date-to`) date ranges for precise control
+- **Selective Deletion**: Only deletes preview files (under `preview.v1/`) - ML upload files (`.v3.gz`) are preserved
+- **Safety**: Dry-run mode by default with detailed reporting, file counts by date/hour, and confirmation prompts
+- **Efficiency**: Uses cached inventory downloads, concurrent CSV processing, and batch deletion for S3 operations
 
 ## Performance & Parallelization
 

--- a/src/preview_wrangler/cli.py
+++ b/src/preview_wrangler/cli.py
@@ -335,7 +335,7 @@ def clean_orphans(ctx, date_from, date_to, days_back, dry_run, report, batch_siz
         )
 
         if not orphaned_files:
-            click.echo("No orphaned data found.")
+            click.echo("No orphaned data found. All projects have valid markers.")
             return
 
         # Calculate statistics

--- a/src/preview_wrangler/cli.py
+++ b/src/preview_wrangler/cli.py
@@ -415,7 +415,7 @@ def clean_orphans(ctx, date_from, date_to, days_back, dry_run, report, batch_siz
 
         # Show sample of what would be deleted
         if dry_run:
-            click.echo(f"\nDRY RUN MODE - No files will be deleted")
+            click.echo("\nDRY RUN MODE - No files will be deleted")
             click.echo(f"Total that would be deleted: {total_files} files ({total_size_gb:.2f} GB)")
             click.echo(f"Files will be deleted in batches of {batch_size}")
 

--- a/src/preview_wrangler/cli.py
+++ b/src/preview_wrangler/cli.py
@@ -13,6 +13,7 @@ from .capture_time_sorter import capture_time_sort
 from .csv_parser import PreviewDirectory
 from .file_downloader import FileDownloader
 from .marker_scanner import MarkerScanner
+from .orphan_cleaner import OrphanCleaner
 from .rotation_corrector_v3 import correct_rotations_v3
 from .s3_client import S3Client
 
@@ -235,6 +236,212 @@ def capture_time_sort_cmd(input_dir, output_dir, overwrite):
 
     except Exception as e:
         logger.exception("Error during capture time sorting")
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+
+@cli.command()
+@click.option(
+    "--date-from",
+    type=str,
+    help="Start date for valid marker files (YYYY-MM-DD format, e.g., 2024-01-01)",
+)
+@click.option(
+    "--date-to",
+    type=str,
+    help="End date for valid marker files (YYYY-MM-DD format, e.g., 2024-01-31). Defaults to today.",
+)
+@click.option(
+    "--days-back",
+    type=int,
+    default=7,
+    help="Number of days to look back for valid marker files (default: 7). Ignored if --date-from is specified.",
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=True,
+    help="Perform a dry run without actually deleting files (default: dry-run)",
+)
+@click.option(
+    "--report",
+    type=click.Path(path_type=Path),
+    help="Save a detailed report to this file",
+)
+@click.option(
+    "--batch-size",
+    type=int,
+    default=1000,
+    help="Number of files to delete in each batch",
+)
+@click.pass_context
+def clean_orphans(ctx, date_from, date_to, days_back, dry_run, report, batch_size):
+    """Find and delete orphaned PREVIEW files (preserves ML upload files).
+
+    This command scans for all preview data in the bucket and identifies projects
+    that don't have valid marker files created within the specified time window.
+    Only preview files (under preview.v1/) are deleted - ML upload files (.v3.gz) are preserved.
+    By default, it performs a dry run to show what would be deleted.
+    """
+    s3_client = ctx.obj["s3_client"]
+    cache_manager = ctx.obj["cache_manager"]
+
+    try:
+        cleaner = OrphanCleaner(s3_client, cache_manager)
+
+        # Parse date arguments
+        start_datetime = None
+        end_datetime = None
+
+        if date_from:
+            try:
+                from datetime import datetime, timezone
+
+                start_datetime = datetime.strptime(date_from, "%Y-%m-%d").replace(
+                    tzinfo=timezone.utc
+                )
+            except ValueError:
+                click.echo(
+                    f"Error: Invalid date format for --date-from: {date_from}. Use YYYY-MM-DD format.",
+                    err=True,
+                )
+                sys.exit(1)
+
+        if date_to:
+            try:
+                from datetime import datetime, timezone
+
+                # Set to end of day (23:59:59)
+                end_datetime = datetime.strptime(date_to, "%Y-%m-%d").replace(
+                    hour=23, minute=59, second=59, tzinfo=timezone.utc
+                )
+            except ValueError:
+                click.echo(
+                    f"Error: Invalid date format for --date-to: {date_to}. Use YYYY-MM-DD format.",
+                    err=True,
+                )
+                sys.exit(1)
+
+        # Display date range info
+        if start_datetime and end_datetime:
+            click.echo(f"Scanning for orphaned data (marker window: {date_from} to {date_to})...")
+        elif start_datetime:
+            click.echo(f"Scanning for orphaned data (marker window: from {date_from} to today)...")
+        else:
+            click.echo(f"Scanning for orphaned data (marker window: last {days_back} days)...")
+
+        # Find orphaned data
+        orphaned_files, total_size = cleaner.find_orphaned_data(
+            days_back=days_back, start_datetime=start_datetime, end_datetime=end_datetime
+        )
+
+        if not orphaned_files:
+            click.echo("No orphaned data found.")
+            return
+
+        # Calculate statistics
+        total_projects = len(orphaned_files)
+        total_files = sum(len(files) for files in orphaned_files.values())
+        total_size_gb = total_size / (1024**3)
+
+        # Collect all distinct date-hours with counts
+        datetime_counts = {}
+        for files in orphaned_files.values():
+            for _, last_modified in files:
+                # Extract date and hour (first 13 characters: YYYY-MM-DDTHH)
+                if len(last_modified) >= 13:
+                    datetime_str = last_modified[:13]  # YYYY-MM-DDTHH
+                elif len(last_modified) >= 10:
+                    datetime_str = last_modified[:10]  # Just date if no time
+                else:
+                    datetime_str = last_modified
+
+                if datetime_str != "unknown":
+                    datetime_counts[datetime_str] = datetime_counts.get(datetime_str, 0) + 1
+
+        click.echo(
+            f"\nFound {total_projects} orphaned projects with {total_files} total files ({total_size_gb:.2f} GB)"
+        )
+
+        if datetime_counts:
+            sorted_datetimes = sorted(datetime_counts.keys())
+            click.echo(
+                f"Files span {len(sorted_datetimes)} distinct date-hours from {sorted_datetimes[0]} to {sorted_datetimes[-1]}"
+            )
+
+            # Show all date-hours with counts
+            click.echo("File counts by date and hour:")
+            for datetime_str in sorted_datetimes:
+                click.echo(f"  {datetime_str}: {datetime_counts[datetime_str]} files")
+
+        # Generate report if requested
+        if report:
+            click.echo(f"\nGenerating report: {report}")
+            cleaner.generate_report(orphaned_files, output_file=report)
+
+        # Show sample of what would be deleted
+        if dry_run:
+            click.echo(f"\nDRY RUN MODE - No files will be deleted")
+            click.echo(f"Total that would be deleted: {total_files} files ({total_size_gb:.2f} GB)")
+            click.echo(f"Files will be deleted in batches of {batch_size}")
+
+            # Sort projects by their most recent file date to show most recent ones first
+            def get_most_recent_date(project_path):
+                files = orphaned_files[project_path]
+                if not files:
+                    return "0000-00-00"  # Fallback for empty projects
+                # Get the most recent datetime from all files in this project
+                datetimes = []
+                for _, last_modified in files:
+                    if len(last_modified) >= 13:
+                        datetimes.append(last_modified[:13])  # YYYY-MM-DDTHH
+                    elif len(last_modified) >= 10:
+                        datetimes.append(last_modified[:10])  # Just date
+                    else:
+                        datetimes.append("0000-00-00")
+                return max(datetimes) if datetimes else "0000-00-00"
+
+            projects_by_recency = sorted(
+                orphaned_files.keys(), key=get_most_recent_date, reverse=True
+            )
+
+            click.echo("\nSample of orphaned projects and files (most recent 5 projects):")
+            for _i, project_path in enumerate(projects_by_recency[:5]):
+                files = orphaned_files[project_path]
+                click.echo(f"  {project_path}: {len(files)} files")
+                # Show first 30 files as examples with dates and hours
+                for file_path, last_modified in files[:30]:
+                    # Format the datetime for better readability
+                    if len(last_modified) >= 13:
+                        datetime_str = last_modified[:13]  # YYYY-MM-DDTHH
+                    elif len(last_modified) >= 10:
+                        datetime_str = last_modified[:10]  # Just date
+                    else:
+                        datetime_str = last_modified
+                    click.echo(f"    - {file_path} (modified: {datetime_str})")
+                if len(files) > 30:
+                    click.echo(f"    ... and {len(files) - 30} more files")
+                click.echo("")
+
+            if total_projects > 5:
+                click.echo(f"  ... and {total_projects - 5} more projects")
+
+            click.echo("\nTo actually delete these files, run with --no-dry-run")
+        else:
+            # Confirm deletion
+            click.confirm(
+                f"\nWARNING: This will delete {total_files} files ({total_size_gb:.2f} GB) from {total_projects} projects. Continue?",
+                abort=True,
+            )
+
+            # Delete the files
+            projects_deleted, files_deleted = cleaner.delete_orphaned_data(
+                orphaned_files, dry_run=False, batch_size=batch_size
+            )
+
+            click.echo(f"\nDeleted {files_deleted} files from {projects_deleted} projects")
+
+    except Exception as e:
+        logger.exception("Error during orphan cleanup")
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
 

--- a/src/preview_wrangler/orphan_cleaner.py
+++ b/src/preview_wrangler/orphan_cleaner.py
@@ -1,0 +1,430 @@
+"""Clean up orphaned preview data using inventory files to cross-check against marker files."""
+
+import csv
+import logging
+import re
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+from tqdm import tqdm
+
+from .cache import CacheManager
+from .csv_downloader import CSVDownloader
+from .inventory import InventoryManager
+from .marker_scanner import MarkerScanner
+from .s3_client import S3Client
+
+logger = logging.getLogger(__name__)
+
+
+def _process_csv_for_projects(csv_path: Path) -> set[tuple[str, str]]:
+    """Process a single CSV file to extract preview directory projects.
+
+    Args:
+        csv_path: Path to CSV file
+
+    Returns:
+        Set of (user_id, project_id) tuples for projects with preview data
+    """
+    preview_pattern = re.compile(r"^([a-f0-9-]{36})/([a-f0-9-]{36})/preview\.v1/")
+    preview_projects = set()
+
+    try:
+        with open(csv_path, encoding="utf-8") as f:
+            reader = csv.reader(f)
+
+            for row in reader:
+                if len(row) < 2:
+                    continue
+
+                key = row[1]  # Key is second column
+
+                # Check for preview directory
+                match = preview_pattern.match(key)
+                if match:
+                    user_uuid = match.group(1)
+                    project_uuid = match.group(2)
+                    preview_projects.add((user_uuid, project_uuid))
+
+    except Exception as e:
+        logger.error(f"Error processing {csv_path}: {e}")
+
+    return preview_projects
+
+
+def _process_csv_for_all_projects(
+    args: tuple[Path, set[tuple[str, str]], Optional[datetime], Optional[datetime]],
+) -> dict[str, list[tuple[str, int, str]]]:
+    """Process a single CSV file to extract preview files and sizes for ALL orphaned projects.
+
+    Much more efficient than processing each project individually - scans each CSV once
+    and collects files for all orphaned projects in a single pass.
+
+    Args:
+        args: Tuple of (csv_path, orphaned_projects_set, start_datetime, end_datetime)
+
+    Returns:
+        Dictionary mapping project paths to lists of (file_path, file_size, last_modified) tuples found in this CSV
+    """
+    csv_path, orphaned_projects_set, start_datetime, end_datetime = args
+    project_files = {}
+
+    try:
+        with open(csv_path, encoding="utf-8") as f:
+            reader = csv.reader(f)
+
+            for row in reader:
+                if len(row) < 4:  # Need bucket, key, size, and last_modified columns
+                    continue
+
+                key = row[1]  # Key is second column
+                try:
+                    size = int(row[2])  # Size is third column
+                except (ValueError, IndexError):
+                    size = 0  # Default to 0 if size can't be parsed
+
+                last_modified = (
+                    row[3] if len(row) > 3 else "unknown"
+                )  # Last modified is fourth column
+
+                # Only process preview files
+                if "/preview.v1/" in key:
+                    # Extract user_id/project_id from path
+                    parts = key.split("/")
+                    if len(parts) >= 3:
+                        user_id, project_id = parts[0], parts[1]
+
+                        # Fast O(1) lookup: is this an orphaned project?
+                        if (user_id, project_id) in orphaned_projects_set:
+                            # Filter by date range if specified
+                            if start_datetime is not None and end_datetime is not None:
+                                try:
+                                    # Parse the last_modified timestamp
+                                    file_datetime = datetime.fromisoformat(
+                                        last_modified.replace("Z", "+00:00")
+                                    )
+                                    if not (start_datetime <= file_datetime <= end_datetime):
+                                        continue  # Skip files outside date range
+                                except (ValueError, AttributeError):
+                                    # Skip files with invalid timestamps when date filtering is active
+                                    continue
+
+                            project_path = f"{user_id}/{project_id}"
+                            if project_path not in project_files:
+                                project_files[project_path] = []
+                            project_files[project_path].append((key, size, last_modified))
+
+    except Exception as e:
+        logger.debug(f"Error processing {csv_path} for all projects: {e}")
+
+    return project_files
+
+
+class OrphanCleaner:
+    """Identifies and removes preview data found in inventory that doesn't have corresponding marker files."""
+
+    MAX_WORKERS = 8  # Process multiple CSV files concurrently
+
+    def __init__(self, s3_client: S3Client, cache_manager: CacheManager):
+        self.s3_client = s3_client
+        self.cache_manager = cache_manager
+        self.bucket = "prod.ml-meta-upload.getnarrativeapp.com"
+        self.marker_scanner = MarkerScanner(s3_client)
+        self.inventory_manager = InventoryManager(s3_client)
+        self.csv_downloader = CSVDownloader(s3_client, cache_manager)
+
+    def find_orphaned_data(
+        self,
+        days_back: int = 7,  # Default to 7 days
+        start_datetime: Optional[datetime] = None,
+        end_datetime: Optional[datetime] = None,
+    ) -> tuple[dict[str, list[tuple[str, str]]], int]:
+        """
+        Find all preview data in inventory that doesn't have corresponding marker files.
+
+        Args:
+            days_back: How many days back to scan for valid markers (default: 7)
+            start_datetime: Optional start datetime (overrides days_back)
+            end_datetime: Optional end datetime (defaults to now)
+
+        Returns:
+            Tuple of (orphaned_files_dict, total_size_bytes)
+            - orphaned_files_dict: Dictionary mapping project paths to lists of (file_path, last_modified) tuples
+            - total_size_bytes: Total size of all orphaned files
+        """
+        if end_datetime is None:
+            end_datetime = datetime.now(timezone.utc)
+
+        if start_datetime is None:
+            start_datetime = end_datetime - timedelta(days=days_back)
+
+        logger.info(f"Scanning for valid marker files from {start_datetime} to {end_datetime}")
+
+        # Step 1: Get all projects with valid marker files
+        valid_projects = set(
+            self.marker_scanner.scan_for_projects(
+                start_datetime=start_datetime, end_datetime=end_datetime
+            )
+        )
+        logger.info(f"Found {len(valid_projects)} projects with valid marker files")
+
+        # Step 2: Download and parse inventory to find ALL preview data
+        logger.info("Downloading latest S3 inventory...")
+        manifest = self.inventory_manager.get_latest_manifest()
+        logger.info(f"Inventory created at: {manifest.creation_date}")
+
+        # Download CSV files
+        csv_paths = self.csv_downloader.download_csv_files(manifest)
+
+        # Parse CSV files to find all preview directories using concurrent processing
+        logger.info(
+            f"Parsing inventory files to find all preview data using {self.MAX_WORKERS} workers..."
+        )
+        all_inventory_projects = self._parse_csv_files_fast(csv_paths)
+        logger.info(
+            f"Found {len(all_inventory_projects)} total projects with preview data in inventory"
+        )
+
+        # Step 3: Find orphaned projects (in inventory but not in markers)
+        orphaned_projects = all_inventory_projects - valid_projects
+        logger.info(f"Found {len(orphaned_projects)} orphaned projects")
+
+        # Step 4: Collect all files from orphaned projects using concurrent processing
+        orphaned_files, total_size = self._get_project_files_fast(
+            list(orphaned_projects), csv_paths, start_datetime, end_datetime
+        )
+
+        return orphaned_files, total_size
+
+    def _parse_csv_files_fast(self, csv_paths: list[Path]) -> set[tuple[str, str]]:
+        """Parse CSV files to find all preview projects using concurrent processing.
+
+        Args:
+            csv_paths: List of CSV file paths
+
+        Returns:
+            Set of (user_id, project_id) tuples for all projects with preview data
+        """
+        all_projects = set()
+
+        # Process CSV files concurrently
+        with ProcessPoolExecutor(max_workers=self.MAX_WORKERS) as executor:
+            # Submit all tasks
+            future_to_csv = {
+                executor.submit(_process_csv_for_projects, csv_path): csv_path
+                for csv_path in csv_paths
+            }
+
+            # Process results as they complete
+            with tqdm(total=len(csv_paths), desc="Processing CSV files") as pbar:
+                for future in as_completed(future_to_csv):
+                    csv_path = future_to_csv[future]
+                    try:
+                        projects = future.result()
+                        all_projects.update(projects)
+                    except Exception as e:
+                        logger.error(f"Failed to process {csv_path}: {e}")
+                    finally:
+                        pbar.update(1)
+
+        return all_projects
+
+    def _get_project_files_fast(
+        self,
+        orphaned_projects: list[tuple[str, str]],
+        csv_paths: list[Path],
+        start_datetime: Optional[datetime] = None,
+        end_datetime: Optional[datetime] = None,
+    ) -> tuple[dict[str, list[tuple[str, str]]], int]:
+        """Get preview files for orphaned projects using optimized single-pass processing.
+
+        Much faster than the previous approach - scans each CSV once instead of once per project.
+
+        Args:
+            orphaned_projects: List of (user_id, project_id) tuples
+            csv_paths: List of CSV file paths
+            start_datetime: Optional start datetime for filtering files
+            end_datetime: Optional end datetime for filtering files
+
+        Returns:
+            Tuple of (project_files_dict, total_size_bytes)
+            - project_files_dict: Dictionary mapping project paths to lists of (file_path, last_modified) tuples
+            - total_size_bytes: Total size of all files that would be deleted
+        """
+        # Convert to set for O(1) lookups
+        orphaned_projects_set = set(orphaned_projects)
+
+        if start_datetime and end_datetime:
+            logger.info(
+                f"Collecting PREVIEW files for {len(orphaned_projects)} projects from {len(csv_paths)} CSV files (date filtered: {start_datetime.date()} to {end_datetime.date()})..."
+            )
+        else:
+            logger.info(
+                f"Collecting PREVIEW files for {len(orphaned_projects)} projects from {len(csv_paths)} CSV files (optimized single-pass)..."
+            )
+
+        all_project_files = {}
+        total_size = 0
+
+        # Process each CSV once to collect files for ALL orphaned projects
+        with ProcessPoolExecutor(max_workers=self.MAX_WORKERS) as executor:
+            # Submit one task per CSV file (not per project!)
+            future_to_csv = {
+                executor.submit(
+                    _process_csv_for_all_projects,
+                    (csv_path, orphaned_projects_set, start_datetime, end_datetime),
+                ): csv_path
+                for csv_path in csv_paths
+            }
+
+            # Process results as they complete
+            with tqdm(total=len(csv_paths), desc="Processing CSV files") as pbar:
+                for future in as_completed(future_to_csv):
+                    csv_path = future_to_csv[future]
+
+                    try:
+                        csv_project_files = future.result()
+
+                        # Merge results from this CSV into the overall results
+                        for project_path, file_data in csv_project_files.items():
+                            if project_path not in all_project_files:
+                                all_project_files[project_path] = []
+
+                            # Extract file paths and dates, accumulate sizes
+                            for file_path, file_size, last_modified in file_data:
+                                all_project_files[project_path].append((file_path, last_modified))
+                                total_size += file_size
+
+                    except Exception as e:
+                        logger.error(f"Failed to process {csv_path}: {e}")
+                    finally:
+                        pbar.update(1)
+
+        logger.info(f"Found files for {len(all_project_files)} orphaned projects")
+        logger.info(f"Total size of orphaned preview files: {total_size / (1024**3):.2f} GB")
+        return all_project_files, total_size
+
+    def delete_orphaned_data(
+        self,
+        orphaned_files: dict[str, list[tuple[str, str]]],
+        dry_run: bool = True,
+        batch_size: int = 1000,
+    ) -> tuple[int, int]:
+        """
+        Delete orphaned PREVIEW files from S3 (preserves ML upload files).
+
+        Args:
+            orphaned_files: Dictionary mapping project paths to lists of (file_path, last_modified) tuples
+            dry_run: If True, don't actually delete, just report what would be deleted
+            batch_size: Number of files to delete in each batch
+
+        Returns:
+            Tuple of (projects_deleted, files_deleted)
+        """
+        total_projects = len(orphaned_files)
+        total_files = sum(len(files) for files in orphaned_files.values())
+
+        if dry_run:
+            logger.info(f"DRY RUN: Would delete {total_files} files from {total_projects} projects")
+            return total_projects, total_files
+
+        logger.info(f"Deleting {total_files} files from {total_projects} projects...")
+
+        files_deleted = 0
+        projects_deleted = 0
+
+        for project_path, files in tqdm(orphaned_files.items(), desc="Deleting projects"):
+            # Safety check: only delete preview files - extract file paths from tuples
+            preview_files = [
+                file_path
+                for file_path, _ in files
+                if "/preview.v1/" in file_path and not file_path.endswith(".v3.gz")
+            ]
+            if len(preview_files) != len(files):
+                logger.warning(
+                    f"Filtered out {len(files) - len(preview_files)} non-preview files from {project_path}"
+                )
+
+            # Delete files in batches
+            for i in range(0, len(preview_files), batch_size):
+                batch = preview_files[i : i + batch_size]
+                delete_objects = [{"Key": key} for key in batch]
+
+                try:
+                    response = self.s3_client.s3.delete_objects(
+                        Bucket=self.bucket, Delete={"Objects": delete_objects, "Quiet": True}
+                    )
+
+                    # Check for errors
+                    if "Errors" in response:
+                        for error in response["Errors"]:
+                            logger.error(
+                                f"Error deleting {error['Key']}: {error['Code']} - {error['Message']}"
+                            )
+                    else:
+                        files_deleted += len(batch)
+
+                except Exception as e:
+                    logger.error(f"Error deleting batch for {project_path}: {e}")
+
+            projects_deleted += 1
+
+        logger.info(f"Deleted {files_deleted} files from {projects_deleted} projects")
+        return projects_deleted, files_deleted
+
+    def generate_report(
+        self, orphaned_files: dict[str, list[tuple[str, str]]], output_file: Optional[Path] = None
+    ) -> str:
+        """
+        Generate a detailed report of orphaned data.
+
+        Args:
+            orphaned_files: Dictionary mapping project paths to lists of (file_path, last_modified) tuples
+            output_file: Optional file path to save the report
+
+        Returns:
+            Report as a string
+        """
+        report_lines = ["# Orphaned Preview Data Report", ""]
+
+        total_projects = len(orphaned_files)
+        total_files = sum(len(files) for files in orphaned_files.values())
+
+        report_lines.append(f"Total orphaned projects: {total_projects}")
+        report_lines.append(f"Total orphaned files: {total_files}")
+        report_lines.append("")
+        report_lines.append("## Projects and Files")
+        report_lines.append("")
+
+        for project_path in sorted(orphaned_files.keys()):
+            files = orphaned_files[project_path]
+            report_lines.append(f"### {project_path}")
+            report_lines.append(f"  Files: {len(files)}")
+
+            # Group files by type - extract file paths from tuples
+            preview_files = [file_path for file_path, _ in files if "/preview.v1/" in file_path]
+            v3_files = [file_path for file_path, _ in files if file_path.endswith(".v3.gz")]
+            other_files = [
+                file_path
+                for file_path, _ in files
+                if file_path not in preview_files and file_path not in v3_files
+            ]
+
+            if preview_files:
+                report_lines.append(f"  - Preview files: {len(preview_files)}")
+            if v3_files:
+                report_lines.append(f"  - V3 files: {len(v3_files)}")
+            if other_files:
+                report_lines.append(f"  - Other files: {len(other_files)}")
+
+            report_lines.append("")
+
+        report = "\n".join(report_lines)
+
+        if output_file:
+            output_file.write_text(report)
+            logger.info(f"Report saved to {output_file}")
+
+        return report

--- a/src/preview_wrangler/orphan_cleaner.py
+++ b/src/preview_wrangler/orphan_cleaner.py
@@ -189,7 +189,9 @@ class OrphanCleaner:
 
         # Step 3: Find orphaned projects (in inventory but not in markers)
         orphaned_projects = all_inventory_projects - valid_projects
+        non_orphaned_projects = all_inventory_projects.intersection(valid_projects)
         logger.info(f"Found {len(orphaned_projects)} orphaned projects")
+        logger.info(f"Found {len(non_orphaned_projects)} non-orphaned projects (have valid markers)")
 
         # Step 4: Collect all files from orphaned projects using concurrent processing
         orphaned_files, total_size = self._get_project_files_fast(

--- a/src/preview_wrangler/orphan_cleaner.py
+++ b/src/preview_wrangler/orphan_cleaner.py
@@ -69,7 +69,7 @@ def _process_csv_for_all_projects(
         Dictionary mapping project paths to lists of (file_path, file_size, last_modified) tuples found in this CSV
     """
     csv_path, orphaned_projects_set, start_datetime, end_datetime = args
-    project_files = {}
+    project_files: dict[str, list[tuple[str, int, str]]] = {}
 
     try:
         with open(csv_path, encoding="utf-8") as f:
@@ -279,7 +279,7 @@ class OrphanCleaner:
                 f"Collecting PREVIEW files for {len(orphaned_projects)} projects from {len(csv_paths)} CSV files (optimized single-pass)..."
             )
 
-        all_project_files = {}
+        all_project_files: dict[str, list[tuple[str, str]]] = {}
         total_size = 0
 
         # Process each CSV once to collect files for ALL orphaned projects


### PR DESCRIPTION
## Summary
- Add `--date-from` and `--date-to` options for precise date control in orphan cleanup
- Filter inventory files by `last_modified` timestamp within specified range
- Enhanced dry-run output with comprehensive file information and date analytics

## Key Features
- **Precise Date Control**: Use `--date-from 2025-07-15 --date-to 2025-07-20` instead of relative `--days-back`
- **File-Level Filtering**: Only processes files last modified within the specified date range
- **Enhanced Analytics**: Shows file counts by date/hour and displays most recent orphaned projects
- **Backward Compatibility**: `--days-back` option still works when date options not specified

## Usage Examples
```bash
# Clean orphans with specific date range
uv run python src/main.py clean-orphans --date-from 2024-01-01 --date-to 2024-01-31

# Clean orphans from specific start date to today
uv run python src/main.py clean-orphans --date-from 2024-01-15

# Still works: clean orphans from last 14 days
uv run python src/main.py clean-orphans --days-back 14
```

## Test plan
- [ ] Test date range filtering with various date combinations
- [ ] Verify file filtering works correctly with inventory timestamps
- [ ] Confirm dry-run output shows accurate date analytics
- [ ] Test backward compatibility with existing `--days-back` option
- [ ] Validate error handling for invalid date formats

🤖 Generated with [Claude Code](https://claude.ai/code)